### PR TITLE
Fix event ordering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
         <log4j.version>2.17.1</log4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <testcontainers.version>1.17.6</testcontainers.version>
     </properties>
     <build>
         <sourceDirectory>src</sourceDirectory>
@@ -80,6 +81,10 @@
             <version>1.7.25</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -94,4 +99,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>${testcontainers.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,11 @@
     <name>kompot</name>
     <description>Message queuing for human use.</description>
     <properties>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.20.0</log4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <testcontainers.version>1.17.6</testcontainers.version>
+        <jedis.version>4.3.1</jedis.version>
     </properties>
     <build>
         <sourceDirectory>src</sourceDirectory>
@@ -55,7 +56,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>3.0.1</version>
+            <version>${jedis.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -89,13 +90,19 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.25</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>hu.dbx</groupId>
     <artifactId>kompot</artifactId>
     <packaging>jar</packaging>
-    <version>0.4.11</version>
+    <version>0.4.12-SNAPSHOT</version>
     <name>kompot</name>
     <description>Message queuing for human use.</description>
     <properties>

--- a/src/hu/dbx/kompot/impl/DataHandling.java
+++ b/src/hu/dbx/kompot/impl/DataHandling.java
@@ -163,12 +163,12 @@ public final class DataHandling {
         }
     }
 
+    private static final long PRIORITY_LEVEL_WEIGHT_OFFSET = 1L << 35; //kb 400 nap (millisecben)
+
     public static void zaddNow(Transaction tx, String sortedSetKey, Priority priority, byte[] value) {
-        long start = 1532092223L; // 2018 july
         long now = System.currentTimeMillis();
 
-        // TODO: test different weight functions!
-        double weight = ((double) start - now) - start * priority.score;
+        double weight = now - priority.score * PRIORITY_LEVEL_WEIGHT_OFFSET;
         tx.zadd(sortedSetKey.getBytes(), weight, value);
     }
 

--- a/src/hu/dbx/kompot/report/Reporting.java
+++ b/src/hu/dbx/kompot/report/Reporting.java
@@ -6,7 +6,11 @@ import hu.dbx.kompot.impl.DataHandling;
 import hu.dbx.kompot.impl.DataHandling.Statuses;
 import hu.dbx.kompot.impl.LoggerUtils;
 import org.slf4j.Logger;
-import redis.clients.jedis.*;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Transaction;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -195,7 +199,7 @@ public final class Reporting implements EventQueries, EventUpdates {
     }
 
 
-    private final static List<Statuses> resendableStatuses = Arrays.asList(Statuses.ERROR, Statuses.PROCESSING);
+    private static final List<Statuses> resendableStatuses = Arrays.asList(Statuses.ERROR, Statuses.PROCESSING);
 
     @Override
     public void resendEvent(UUID eventUuid, String eventGroup) {

--- a/src/hu/dbx/kompot/status/SelfStatusWriter.java
+++ b/src/hu/dbx/kompot/status/SelfStatusWriter.java
@@ -3,9 +3,9 @@ package hu.dbx.kompot.status;
 import hu.dbx.kompot.core.KeyNaming;
 import hu.dbx.kompot.impl.consumer.ConsumerConfig;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.ScanParams;
-import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.Transaction;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
 
 import java.util.Date;
 import java.util.HashSet;

--- a/test-resources/log4j.properties
+++ b/test-resources/log4j.properties
@@ -1,4 +1,7 @@
-log4j.rootLogger=DEBUG, console
+log4j.rootLogger=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=[%d] %-5p %c: %m%n
+
+log4j.logger.hu.dbx=DEBUG, console
+log4j.additivity.hu.dbx=false

--- a/test-resources/log4j.properties
+++ b/test-resources/log4j.properties
@@ -1,7 +1,7 @@
 log4j.rootLogger=INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=[%d] %-5p %c: %m%n
+log4j.appender.console.layout.ConversionPattern=[%d] [%t] %-5p %c: %m%n
 
 log4j.logger.hu.dbx=DEBUG, console
 log4j.additivity.hu.dbx=false

--- a/test/hu/dbx/kompot/TestRedis.java
+++ b/test/hu/dbx/kompot/TestRedis.java
@@ -27,14 +27,14 @@ public class TestRedis extends ExternalResource {
         return new TestRedis();
     }
 
-    public TestRedis() {
+    private TestRedis() {
         try {
             if (System.getenv().containsKey(ENV_KEY)) {
                 redis = null;
                 uri = new URI(System.getenv(ENV_KEY));
             } else {
                 LOGGER.debug("Initializing redis docker container");
-                redis = new GenericContainer(DockerImageName.parse("redis:7.0.8-alpine"))
+                redis = new GenericContainer(DockerImageName.parse("redis:5.0.3-alpine"))
                         .withExposedPorts(6379);
                 redis.start();
                 uri = new URI("redis://" + redis.getHost() + ":" + redis.getMappedPort(6379) + "/13");
@@ -46,10 +46,6 @@ public class TestRedis extends ExternalResource {
 
     @Override
     public void before() {
-        if (redis != null && !redis.isRunning()) {
-            LOGGER.debug("Starting redis");
-            redis.start();
-        }
         pool = new JedisPool(uri);
         try (Jedis jedis = pool.getResource()) {
             LOGGER.trace(jedis.info());
@@ -59,10 +55,6 @@ public class TestRedis extends ExternalResource {
 
     @Override
     public void after() {
-        if (redis != null && redis.isRunning()) {
-            LOGGER.debug("Stopping redis container");
-            redis.stop();
-        }
         pool.close();
     }
 

--- a/test/hu/dbx/kompot/TestRedis.java
+++ b/test/hu/dbx/kompot/TestRedis.java
@@ -4,6 +4,7 @@ import hu.dbx.kompot.impl.LoggerUtils;
 import org.junit.rules.ExternalResource;
 import org.slf4j.Logger;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
@@ -35,7 +36,8 @@ public class TestRedis extends ExternalResource {
             } else {
                 LOGGER.debug("Initializing redis docker container");
                 redis = new GenericContainer(DockerImageName.parse("redis:5.0.3-alpine"))
-                        .withExposedPorts(6379);
+                        .withExposedPorts(6379)
+                        .waitingFor(Wait.forListeningPort());
                 redis.start();
                 uri = new URI("redis://" + redis.getHost() + ":" + redis.getMappedPort(6379) + "/13");
             }

--- a/test/hu/dbx/kompot/ng/AbstractRedisTest.java
+++ b/test/hu/dbx/kompot/ng/AbstractRedisTest.java
@@ -1,0 +1,8 @@
+package hu.dbx.kompot.ng;
+
+import hu.dbx.kompot.TestRedis;
+import org.junit.ClassRule;
+
+public abstract class AbstractRedisTest {
+    @ClassRule public static TestRedis redis = TestRedis.build();
+}

--- a/test/hu/dbx/kompot/ng/broadcast/Broadcast1Test.java
+++ b/test/hu/dbx/kompot/ng/broadcast/Broadcast1Test.java
@@ -1,34 +1,32 @@
 package hu.dbx.kompot.ng.broadcast;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.broadcast.handler.BroadcastDescriptor;
 import hu.dbx.kompot.consumer.broadcast.handler.SelfDescribingBroadcastProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
-import org.junit.Rule;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
-import static org.junit.Assert.assertEquals;
+import static org.awaitility.Awaitility.await;
 
 /**
  * Elkuldtunk egy broadcast uzenetet, valaki figyelt is ra.
  */
-public class Broadcast1Test {
+public class Broadcast1Test extends AbstractRedisTest {
 
 
     private static final BroadcastDescriptor<String> BROADCAST1 = BroadcastDescriptor.of("BC1", String.class);
 
     private static final ConsumerIdentity serverIdentity = groupGroup("Consumer");
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Test
     public void testSuccessfullyHandleEvent() throws SerializationException, InterruptedException {
@@ -47,11 +45,10 @@ public class Broadcast1Test {
         // kikuldunk egy broadcast esemenyt
         producer.broadcast(BROADCAST1, "msg1");
 
-        Thread.sleep(1000);
+        await("Consumer should process the event").atMost(1, TimeUnit.SECONDS).untilAtomic(counter, Matchers.is(1L));
         producer.stop();
         consumer.stop();
         executor.shutdown();
-
-        assertEquals(1L, counter.get());
+        await("Executor should terminate").atMost(10, TimeUnit.SECONDS).until(executor::isTerminated);
     }
 }

--- a/test/hu/dbx/kompot/ng/broadcast/BroadcastMultiTest.java
+++ b/test/hu/dbx/kompot/ng/broadcast/BroadcastMultiTest.java
@@ -33,10 +33,10 @@ public class BroadcastMultiTest extends AbstractRedisTest {
 
     private static final ConsumerIdentity serverIdentity = groupGroup("Consumer");
 
-    private static final int CONSUMER_COUNT = 30;
+    private static final int CONSUMER_COUNT = 10;
 
     @Test
-    public void testSuccessfullyHandleEvent() throws SerializationException, InterruptedException {
+    public void testSuccessfullyHandleEvent() throws SerializationException {
         final ExecutorService executor = Executors.newFixedThreadPool(10);
         final AtomicInteger counter = new AtomicInteger(0);
 

--- a/test/hu/dbx/kompot/ng/broadcast/BroadcastMultiTest.java
+++ b/test/hu/dbx/kompot/ng/broadcast/BroadcastMultiTest.java
@@ -1,68 +1,71 @@
 package hu.dbx.kompot.ng.broadcast;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.broadcast.handler.BroadcastDescriptor;
 import hu.dbx.kompot.consumer.broadcast.handler.SelfDescribingBroadcastProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
-import org.junit.Rule;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Stream;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.stream.Collectors.toList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Kikuldunk egy broadcast esemenyt es ellenorizzuk, hogy mind a negy feliratkozo megkapta.
  */
-public class BroadcastMultiTest {
+public class BroadcastMultiTest extends AbstractRedisTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BroadcastMultiTest.class);
 
     private static final BroadcastDescriptor<String> BROADCAST1 = BroadcastDescriptor.of("BC1", String.class);
 
     private static final ConsumerIdentity serverIdentity = groupGroup("Consumer");
 
-    @Rule
-    public TestRedis redis = TestRedis.build();
+    private static final int CONSUMER_COUNT = 30;
 
     @Test
     public void testSuccessfullyHandleEvent() throws SerializationException, InterruptedException {
         final ExecutorService executor = Executors.newFixedThreadPool(10);
-        final AtomicLong counter = new AtomicLong(0);
+        final AtomicInteger counter = new AtomicInteger(0);
 
         final CommunicationEndpoint producer = CommunicationEndpoint.ofRedisConnectionUri(redis.getConnectionURI(), EventGroupProvider.identity(), serverIdentity, executor);
 
         producer.start();
 
-        List<CommunicationEndpoint> consumers = Stream.of(1, 2, 3, 4).map(__ -> startConsumer(executor, counter)).collect(toList());
+        List<CommunicationEndpoint> consumers = IntStream.rangeClosed(1, CONSUMER_COUNT).mapToObj(__ -> startConsumer(executor, counter)).collect(toList());
 
         // kikuldunk egy broadcast esemenyt
         producer.broadcast(BROADCAST1, "msg1");
 
-        Thread.sleep(1000);
         producer.stop();
+
+        await("Counter should reach consumer count").atMost(5, TimeUnit.SECONDS).untilAtomic(counter, is(CONSUMER_COUNT));
 
         consumers.forEach(CommunicationEndpoint::stop);
 
         executor.shutdown();
-        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
-
-        assertEquals(4L, counter.get());
+        await("Executor should terminate").atMost(5, TimeUnit.SECONDS).until(executor::isTerminated);
     }
 
-    private CommunicationEndpoint startConsumer(ExecutorService executor, AtomicLong counter) {
+    private CommunicationEndpoint startConsumer(ExecutorService executor, AtomicInteger counter) {
         final CommunicationEndpoint server = CommunicationEndpoint.ofRedisConnectionUri(redis.getConnectionURI(), EventGroupProvider.identity(), serverIdentity, executor);
 
-        server.registerBroadcastProcessor(SelfDescribingBroadcastProcessor.of(BROADCAST1, x -> counter.incrementAndGet()));
+        server.registerBroadcastProcessor(SelfDescribingBroadcastProcessor.of(BROADCAST1, x -> {
+            LOGGER.debug("Received broadcast: {}", x);
+            counter.incrementAndGet();
+        }));
         server.start();
 
         return server;

--- a/test/hu/dbx/kompot/ng/broadcast/BroadcastWithoutConsumersTest.java
+++ b/test/hu/dbx/kompot/ng/broadcast/BroadcastWithoutConsumersTest.java
@@ -1,12 +1,11 @@
 package hu.dbx.kompot.ng.broadcast;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.broadcast.handler.BroadcastDescriptor;
 import hu.dbx.kompot.exceptions.SerializationException;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
@@ -19,15 +18,12 @@ import static org.junit.Assert.assertTrue;
 /**
  * El tudunk kuldeni sok broadcast esemenyt ugy igy, hogy nincsen consumer, aki figyelne ra.
  */
-public class BroadcastWithoutConsumersTest {
+public class BroadcastWithoutConsumersTest extends AbstractRedisTest {
 
 
     private static final BroadcastDescriptor<String> BROADCAST1 = BroadcastDescriptor.of("BC1", String.class);
 
     private static final ConsumerIdentity serverIdentity = groupGroup("Consumer");
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Test
     public void testEventsAreUnhandled() {

--- a/test/hu/dbx/kompot/ng/compressing/DataCompressingTest.java
+++ b/test/hu/dbx/kompot/ng/compressing/DataCompressingTest.java
@@ -1,14 +1,16 @@
 package hu.dbx.kompot.ng.compressing;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.sync.MethodDescriptor;
 import hu.dbx.kompot.consumer.sync.handler.SelfDescribingMethodProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.LoggerUtils;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.slf4j.Logger;
 
 import java.util.*;
@@ -16,9 +18,10 @@ import java.util.concurrent.*;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.Collections.singletonMap;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
-public class DataCompressingTest {
+public class DataCompressingTest extends AbstractRedisTest {
 
     private static final Logger LOGGER = LoggerUtils.getLogger();
 
@@ -30,9 +33,6 @@ public class DataCompressingTest {
     private static final String ROOT_KEY = "root";
     private static final String DATA1 = buildBigData('1');
     private static final String DATA2 = buildBigData('2');
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     private List<Map.Entry<String, Long>> memoryTestResults;
 
@@ -61,7 +61,7 @@ public class DataCompressingTest {
         System.gc();
         registerMemoryUsage("1");
 
-        Thread.sleep(1000);
+        await("Consumer should run at least 1 second").during(1, TimeUnit.SECONDS).atMost(2, TimeUnit.SECONDS).until(() -> consumer.isRunning());
         @SuppressWarnings("unchecked")
         CompletableFuture<Map> response = producer.syncCallMethod(METHOD_1.withTimeout(100_000), singletonMap(ROOT_KEY, DATA1));
 

--- a/test/hu/dbx/kompot/ng/events/EventHandlingDelayedSuccessTest.java
+++ b/test/hu/dbx/kompot/ng/events/EventHandlingDelayedSuccessTest.java
@@ -1,73 +1,75 @@
 package hu.dbx.kompot.ng.events;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.consumer.async.handler.SelfDescribingEventProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.LoggerUtils;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
-import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.Collections.singletonMap;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Elinditunk egy esemenyt. A szerver csak kesobb indul el es csak kesobb kezdi el feldolgozni (sikeresen).
  */
 @SuppressWarnings("unchecked")
-public class EventHandlingDelayedSuccessTest {
+public class EventHandlingDelayedSuccessTest extends AbstractRedisTest {
     private static final Logger LOGGER = LoggerUtils.getLogger();
 
     private static final EventDescriptor EVENT_1 = EventDescriptor.of("EVENT1", Map.class);
     private static final ConsumerIdentity consumerIdentity = groupGroup("EVENT1");
     private static final ConsumerIdentity producerIdentity = groupGroup("XXX");
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
+    private static final int EVENT_COUNT = 100;
 
     @Test
     public void testEventsSentThenLaterReceived() throws InterruptedException, SerializationException {
-        final ExecutorService executor = Executors.newFixedThreadPool(4);
+        final ExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
         final CommunicationEndpoint producer = CommunicationEndpoint.ofRedisConnectionUri(redis.getConnectionURI(), EventGroupProvider.identity(), producerIdentity, executor);
         producer.start();
-        for (int i = 0; i < 10; i++) {
-            producer.asyncSendEvent(EVENT_1, singletonMap("aa", 11));
+        for (int i = 0; i < EVENT_COUNT; i++) {
+            producer.asyncSendEvent(EVENT_1, singletonMap("aa", i));
         }
+        producer.stop();
 
-        executor.awaitTermination(3, TimeUnit.SECONDS);
-
-        final AtomicInteger counter = new AtomicInteger(0);
+        final CopyOnWriteArrayList<Integer> counter = new CopyOnWriteArrayList();
         CommunicationEndpoint consumer = startConsumer(counter, executor);
 
-
-        assertEquals(counter.get(), 0);
-
-        executor.awaitTermination(3, TimeUnit.SECONDS);
-
-        assertEquals(10, counter.get());
-
-        producer.stop();
+        await().atMost(10, TimeUnit.SECONDS).until(() -> counter.size() == EVENT_COUNT);
         consumer.stop();
+        executor.shutdown();
+        await("Executor should be terminated").atMost(3, TimeUnit.SECONDS).until(executor::isTerminated);
+
+        assertEquals(EVENT_COUNT, counter.size());
+
+        final int middleEvent = counter.stream().skip(EVENT_COUNT / 2).findFirst().orElseThrow(() -> new RuntimeException("No value found in the middle"));
+        final int lastEvent = counter.stream().skip(EVENT_COUNT - 1).findFirst().orElseThrow(() -> new RuntimeException("No event found at the end"));
+
+        assertTrue("The last received events should have a higher order than the middle one.",
+                lastEvent > middleEvent);
     }
 
-    private CommunicationEndpoint startConsumer(AtomicInteger counter, ExecutorService executor) {
+    private CommunicationEndpoint startConsumer(List<Integer> counter, ExecutorService executor) {
         final CommunicationEndpoint consumer = CommunicationEndpoint.ofRedisConnectionUri(redis.getConnectionURI(), EventGroupProvider.identity(), consumerIdentity, executor);
         consumer.registerEventHandler(SelfDescribingEventProcessor.of(EVENT_1, (data, meta, callback) -> {
             LOGGER.info("Processed");
             callback.success("OK");
-            counter.incrementAndGet();
+            counter.add(((Map<String, Integer>) data).get("aa"));
         }));
         consumer.start();
         return consumer;

--- a/test/hu/dbx/kompot/ng/events/EventsHandlingSuccessTest.java
+++ b/test/hu/dbx/kompot/ng/events/EventsHandlingSuccessTest.java
@@ -1,16 +1,15 @@
 package hu.dbx.kompot.ng.events;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.consumer.async.handler.SelfDescribingEventProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.LoggerUtils;
 import hu.dbx.kompot.moby.MetaDataHolder;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.producer.ProducerIdentity;
-import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -22,20 +21,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.is;
 
 @SuppressWarnings("unchecked")
-public class EventsHandlingSuccessTest {
+public class EventsHandlingSuccessTest extends AbstractRedisTest {
     private static final Logger LOGGER = LoggerUtils.getLogger();
 
     private static final EventDescriptor EVENT_1 = EventDescriptor.of("EVENT123", Map.class);
     private static final ConsumerIdentity sourceConsumerIdentity = groupGroup("EVENTCProducer");
     private static final ProducerIdentity sourceProducerIdentity = new ProducerIdentity.DetailedIdentity("PROD_MOD", "v1");
     private static final ConsumerIdentity targetConsumerIdentity = groupGroup("EVENT123");
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     /**
      * Sikeresen elkuldunk es feldolgozunk 10 eventet.
@@ -56,15 +52,11 @@ public class EventsHandlingSuccessTest {
             sourceModule.asyncSendEvent(EVENT_1, singletonMap("aa", i), MetaDataHolder.build("cid", "uref", "sourceName", 1234L));
         }
 
-        Thread.sleep(1000);
-        assertNotEquals(0, counter.get());
-
+        await("10 events should be processed").atMost(10, TimeUnit.SECONDS).untilAtomic(counter, is(10));
         sourceModule.stop();
         targetModule.stop();
         executor.shutdown();
-        executor.awaitTermination(10, TimeUnit.SECONDS);
-
-        assertEquals(10, counter.get());
+        await("Executor should be terminated").atMost(10, TimeUnit.SECONDS).until(executor::isTerminated);
     }
 
     private CommunicationEndpoint startTarget(AtomicInteger counter, ExecutorService executor) {

--- a/test/hu/dbx/kompot/ng/massive/LotsOfQuickEventHandlingTest.java
+++ b/test/hu/dbx/kompot/ng/massive/LotsOfQuickEventHandlingTest.java
@@ -1,12 +1,11 @@
 package hu.dbx.kompot.ng.massive;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.consumer.async.handler.SelfDescribingEventProcessor;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.net.URI;
@@ -31,11 +30,7 @@ import static junit.framework.TestCase.assertEquals;
  * <p>
  * We check here for race conditions. On some occasions events used to get stuck when event processing was too quick.
  */
-public class LotsOfQuickEventHandlingTest {
-
-    @Rule
-    public final TestRedis redis = TestRedis.build();
-
+public class LotsOfQuickEventHandlingTest extends AbstractRedisTest {
 
     private static final int EVENT_COUNT = 1000;
     private static final String EVENT_NAME = UUID.randomUUID().toString();
@@ -90,7 +85,8 @@ public class LotsOfQuickEventHandlingTest {
         for (int i = 0; i < EVENT_COUNT; i++) {
             sender.asyncSendEvent(EVENT1, singletonMap("a", 2));
         }
-        executor.awaitTermination(6, TimeUnit.SECONDS);
         sender.stop();
+        executor.shutdown();
+        executor.awaitTermination(5, TimeUnit.SECONDS);
     }
 }

--- a/test/hu/dbx/kompot/ng/massive/MassiveTest.java
+++ b/test/hu/dbx/kompot/ng/massive/MassiveTest.java
@@ -1,7 +1,6 @@
 package hu.dbx.kompot.ng.massive;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.consumer.async.handler.SelfDescribingEventProcessor;
@@ -9,9 +8,9 @@ import hu.dbx.kompot.consumer.broadcast.handler.BroadcastDescriptor;
 import hu.dbx.kompot.consumer.broadcast.handler.SelfDescribingBroadcastProcessor;
 import hu.dbx.kompot.consumer.sync.MethodDescriptor;
 import hu.dbx.kompot.consumer.sync.handler.SelfDescribingMethodProcessor;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,16 +25,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.*;
+import static org.awaitility.Awaitility.await;
 
 @SuppressWarnings("java:S2925")
-public class MassiveTest {
+public class MassiveTest extends AbstractRedisTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MassiveTest.class);
 
     public static final int AGENT_COUNT = 10, EVENT_COUNT = 110, MESSAGE_COUNT = 120, BROADCAST_COUNT = 130;
-
-    @Rule
-    public final TestRedis redis = TestRedis.build();
 
     @Test
     public void test() throws InterruptedException {
@@ -62,7 +59,7 @@ public class MassiveTest {
 
         LOGGER.debug("Waiting for agents to finish");
         service.shutdown();
-        service.awaitTermination(300, TimeUnit.SECONDS);
+        await("Executor should terminate").atMost(300, TimeUnit.SECONDS).until(service::isTerminated);
 
         LOGGER.debug("Agents finished");
 

--- a/test/hu/dbx/kompot/ng/methods/MethodHandlingRemoteExceptionTest.java
+++ b/test/hu/dbx/kompot/ng/methods/MethodHandlingRemoteExceptionTest.java
@@ -1,14 +1,13 @@
 package hu.dbx.kompot.ng.methods;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.sync.MethodDescriptor;
 import hu.dbx.kompot.consumer.sync.handler.SelfDescribingMethodProcessor;
 import hu.dbx.kompot.exceptions.MessageErrorResultException;
 import hu.dbx.kompot.exceptions.SerializationException;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Map;
@@ -23,16 +22,13 @@ import static org.junit.Assert.fail;
  * A tuloldalon kivetel kepzodott.
  */
 @SuppressWarnings("unchecked")
-public class MethodHandlingRemoteExceptionTest {
+public class MethodHandlingRemoteExceptionTest extends AbstractRedisTest {
 
     private static final MethodDescriptor METHOD_1 = MethodDescriptor.ofName("GROUP1", "method1");
     private static final ConsumerIdentity consumerIdentity = groupGroup("GROUP1");
     private static final ConsumerIdentity producerIdentity = groupGroup("GROUP2");
 
     private static String EXCEPTION_MSG = "Now, I am become Death, the destroyer of worlds";
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Test
     public void testHaHibaTortenikAkkorMegkapom() throws InterruptedException, SerializationException {

--- a/test/hu/dbx/kompot/ng/methods/MethodHandlingRemoteReturnsNullTest.java
+++ b/test/hu/dbx/kompot/ng/methods/MethodHandlingRemoteReturnsNullTest.java
@@ -1,13 +1,12 @@
 package hu.dbx.kompot.ng.methods;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.sync.MethodDescriptor;
 import hu.dbx.kompot.consumer.sync.handler.SelfDescribingMethodProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.Map;
@@ -19,14 +18,11 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 @SuppressWarnings("unchecked")
-public class MethodHandlingRemoteReturnsNullTest {
+public class MethodHandlingRemoteReturnsNullTest extends AbstractRedisTest {
 
     private static final MethodDescriptor METHOD_1 = MethodDescriptor.ofName("GROUP1", "method1");
     private static final ConsumerIdentity consumerIdentity = groupGroup("GROUP1");
     private static final ConsumerIdentity producerIdentity = groupGroup("GROUP2");
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     /**
      * When response is a null value then we receive it.

--- a/test/hu/dbx/kompot/ng/methods/MethodHandlingSuccessTest.java
+++ b/test/hu/dbx/kompot/ng/methods/MethodHandlingSuccessTest.java
@@ -1,15 +1,14 @@
 package hu.dbx.kompot.ng.methods;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.sync.MethodDescriptor;
 import hu.dbx.kompot.consumer.sync.handler.SelfDescribingMethodProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.LoggerUtils;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.producer.ProducerIdentity;
-import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 
@@ -18,10 +17,11 @@ import java.util.concurrent.*;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.Collections.singletonMap;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings("unchecked")
-public class MethodHandlingSuccessTest {
+public class MethodHandlingSuccessTest extends AbstractRedisTest {
     private static final Logger LOGGER = LoggerUtils.getLogger();
 
     private static final MethodDescriptor METHOD_1 = MethodDescriptor.ofName("MOD_TARGET", "METHOD1");
@@ -30,9 +30,6 @@ public class MethodHandlingSuccessTest {
     private static final ConsumerIdentity sourceConsumerIdentity = groupGroup("MOD_SOURCE");
     private static final ProducerIdentity sourceProducerIdentity = new ProducerIdentity.DetailedIdentity("MOD_SOURCE", "v1");
 
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     /**
      * Valaszolunk a metodus hivasra
@@ -56,7 +53,7 @@ public class MethodHandlingSuccessTest {
 
         final CommunicationEndpoint consumer = startConsumer(executor);
 
-        Thread.sleep(1000);
+        await("Consumer should run at least half second").during(500, TimeUnit.MILLISECONDS).atMost(2, TimeUnit.SECONDS).until(() -> consumer.isRunning());
         CompletableFuture<Map> response = producer.syncCallMethod(METHOD_1.withTimeout(100_000), singletonMap("aa", 11));
 
         assertEquals(1, response.get(3, TimeUnit.SECONDS).get("a"));

--- a/test/hu/dbx/kompot/ng/reports/ClearProcessedEventsTest.java
+++ b/test/hu/dbx/kompot/ng/reports/ClearProcessedEventsTest.java
@@ -8,46 +8,31 @@ import hu.dbx.kompot.consumer.async.handler.SelfDescribingEventProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.DataHandling;
 import hu.dbx.kompot.impl.DefaultKeyNaming;
-import hu.dbx.kompot.impl.LoggerUtils;
 import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.report.EventFilters;
 import hu.dbx.kompot.report.ListResult;
 import hu.dbx.kompot.report.Pagination;
 import hu.dbx.kompot.report.Reporting;
-import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import redis.clients.jedis.Jedis;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
-import static java.util.Collections.singletonMap;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
 public class ClearProcessedEventsTest extends AbstractRedisTest {
 
-    private static final Logger LOGGER = LoggerUtils.getLogger();
-
     private static final String CONSUMER_CODE = "CONS_CLEAR_PROCESSED_EVENTS_TEST";
-    private static final EventDescriptor<Map> EVENT_1 = EventDescriptor.of(CONSUMER_CODE, Map.class);
+    private static final EventDescriptor<Integer> EVENT_1 = EventDescriptor.of(CONSUMER_CODE, Integer.class);
     private static final ConsumerIdentity consumerIdentity = groupGroup(CONSUMER_CODE);
     private static final ConsumerIdentity producerIdentity = groupGroup("EVENTP");
 
     private static final Pagination THOUSAND = Pagination.fromOffsetAndLimit(0, 1000);
-
-    @Before
-    public void cleanup() {
-        try (Jedis jedis = redis.getJedisPool().getResource()) {
-            jedis.flushDB();
-        }
-    }
 
     /**
      * GIVEN: Küldünk 4 eseményt. Ötöt sikeresen feldolgozunk belőlük, ötöt eldobunk hibával.
@@ -55,7 +40,7 @@ public class ClearProcessedEventsTest extends AbstractRedisTest {
      * THEN: Az 2 sikeresen feldolgozott esemény eltűnik
      */
     @Test
-    public void testClearProcessed() throws SerializationException, InterruptedException {
+    public void testClearProcessed() throws SerializationException {
 
         final ExecutorService executor = Executors.newFixedThreadPool(4);
         //TODO: ezt a DefaultKeyNaming.ofPrefix-et nem itt kellene hívni, hanem legalábbis a CommunicationEndpoint-tól lekérni
@@ -67,7 +52,7 @@ public class ClearProcessedEventsTest extends AbstractRedisTest {
         final int eventCount = 400;
 
         for (int i = 0; i < eventCount; i++) {
-            producer.asyncSendEvent(EVENT_1, singletonMap("index", i));
+            producer.asyncSendEvent(EVENT_1, i);
         }
 
         {
@@ -80,7 +65,7 @@ public class ClearProcessedEventsTest extends AbstractRedisTest {
 
         final CommunicationEndpoint consumer = CommunicationEndpoint.ofRedisConnectionUri(redis.getConnectionURI(), EventGroupProvider.empty(), consumerIdentity, executor);
         consumer.registerEventHandler(SelfDescribingEventProcessor.of(EVENT_1, (data, meta, callback) -> {
-            final int index = (int) data.get("index");
+            final int index = data;
 
             //az események felét hibaként eldobjuk, hogy azt az ágat is lehessen tesztelni
             if (index % 2 == 1) {

--- a/test/hu/dbx/kompot/ng/reports/ClearProcessedEventsTest.java
+++ b/test/hu/dbx/kompot/ng/reports/ClearProcessedEventsTest.java
@@ -2,7 +2,6 @@ package hu.dbx.kompot.ng.reports;
 
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.consumer.async.handler.SelfDescribingEventProcessor;
@@ -10,13 +9,13 @@ import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.DataHandling;
 import hu.dbx.kompot.impl.DefaultKeyNaming;
 import hu.dbx.kompot.impl.LoggerUtils;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.report.EventFilters;
 import hu.dbx.kompot.report.ListResult;
 import hu.dbx.kompot.report.Pagination;
 import hu.dbx.kompot.report.Reporting;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import redis.clients.jedis.Jedis;
@@ -25,12 +24,14 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.Collections.singletonMap;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 
-public class ClearProcessedEventsTest {
+public class ClearProcessedEventsTest extends AbstractRedisTest {
 
     private static final Logger LOGGER = LoggerUtils.getLogger();
 
@@ -40,9 +41,6 @@ public class ClearProcessedEventsTest {
     private static final ConsumerIdentity producerIdentity = groupGroup("EVENTP");
 
     private static final Pagination THOUSAND = Pagination.fromOffsetAndLimit(0, 1000);
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Before
     public void cleanup() {
@@ -93,7 +91,10 @@ public class ClearProcessedEventsTest {
         }));
         consumer.start();
 
-        Thread.sleep(2000);
+        await("Consumer should run at least 1 seconds")
+                .during(1, TimeUnit.SECONDS)
+                .atMost(2, TimeUnit.SECONDS)
+                .until(consumer::isRunning);
 
         try {
             {

--- a/test/hu/dbx/kompot/ng/reports/QueryEventGroups.java
+++ b/test/hu/dbx/kompot/ng/reports/QueryEventGroups.java
@@ -2,16 +2,15 @@ package hu.dbx.kompot.ng.reports;
 
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.DefaultKeyNaming;
 import hu.dbx.kompot.impl.LoggerUtils;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.report.Reporting;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import redis.clients.jedis.Jedis;
@@ -28,7 +27,7 @@ import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class QueryEventGroups {
+public class QueryEventGroups extends AbstractRedisTest {
 
     private static final Logger LOGGER = LoggerUtils.getLogger();
 
@@ -36,9 +35,6 @@ public class QueryEventGroups {
     private static final EventDescriptor<Map> EVENT_2 = EventDescriptor.of("EVENT2", Map.class);
     private static final ConsumerIdentity producerIdentity = groupGroup("PROD");
 
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Before
     public void before() {

--- a/test/hu/dbx/kompot/ng/reports/QueryEventGroupsTest.java
+++ b/test/hu/dbx/kompot/ng/reports/QueryEventGroupsTest.java
@@ -6,42 +6,26 @@ import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.DefaultKeyNaming;
-import hu.dbx.kompot.impl.LoggerUtils;
 import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.report.Reporting;
-import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import redis.clients.jedis.Jedis;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
-import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class QueryEventGroups extends AbstractRedisTest {
+public class QueryEventGroupsTest extends AbstractRedisTest {
 
-    private static final Logger LOGGER = LoggerUtils.getLogger();
-
-    private static final EventDescriptor<Map> EVENT_1 = EventDescriptor.of("EVENT1", Map.class);
-    private static final EventDescriptor<Map> EVENT_2 = EventDescriptor.of("EVENT2", Map.class);
+    private static final EventDescriptor<String> EVENT_1 = EventDescriptor.of("EVENT1", String.class);
+    private static final EventDescriptor<String> EVENT_2 = EventDescriptor.of("EVENT2", String.class);
     private static final ConsumerIdentity producerIdentity = groupGroup("PROD");
-
-
-    @Before
-    public void before() {
-        try (Jedis jedis = redis.getJedisPool().getResource()) {
-            jedis.flushDB();
-        }
-    }
 
     @Test
     public void queryEventGroups() throws SerializationException {
@@ -51,11 +35,11 @@ public class QueryEventGroups extends AbstractRedisTest {
 
         final CommunicationEndpoint producer = CommunicationEndpoint.ofRedisConnectionUri(redis.getConnectionURI(), EventGroupProvider.identity(), producerIdentity, executor);
         producer.start();
-        producer.asyncSendEvent(EVENT_1, singletonMap("aa", 0));
+        producer.asyncSendEvent(EVENT_1, "aa");
 
         assertEquals(1, reporting.listAllEventGroups().size());
 
-        producer.asyncSendEvent(EVENT_2, singletonMap("bb", 1));
+        producer.asyncSendEvent(EVENT_2, "bb");
 
         producer.stop();
 

--- a/test/hu/dbx/kompot/ng/reports/QueryEventsTest.java
+++ b/test/hu/dbx/kompot/ng/reports/QueryEventsTest.java
@@ -1,22 +1,19 @@
 package hu.dbx.kompot.ng.reports;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.DataHandling;
 import hu.dbx.kompot.impl.DefaultKeyNaming;
-import hu.dbx.kompot.impl.LoggerUtils;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.report.EventFilters;
 import hu.dbx.kompot.report.ListResult;
 import hu.dbx.kompot.report.Pagination;
 import hu.dbx.kompot.report.Reporting;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.slf4j.Logger;
 import redis.clients.jedis.Jedis;
 
 import java.util.Map;
@@ -28,15 +25,12 @@ import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 
-public class QueryEventsTest {
+public class QueryEventsTest extends AbstractRedisTest {
 
     private static final EventDescriptor<Map> EVENT_1 = EventDescriptor.of("EVENT2", Map.class);
     private static final ConsumerIdentity producerIdentity = groupGroup("EVENTP");
 
     private static final Pagination THOUSAND = Pagination.fromOffsetAndLimit(0, 1000);
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Before
     public void cleanup() {

--- a/test/hu/dbx/kompot/ng/reports/QueryEventsTest.java
+++ b/test/hu/dbx/kompot/ng/reports/QueryEventsTest.java
@@ -12,35 +12,24 @@ import hu.dbx.kompot.report.EventFilters;
 import hu.dbx.kompot.report.ListResult;
 import hu.dbx.kompot.report.Pagination;
 import hu.dbx.kompot.report.Reporting;
-import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
-import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 
 public class QueryEventsTest extends AbstractRedisTest {
 
-    private static final EventDescriptor<Map> EVENT_1 = EventDescriptor.of("EVENT2", Map.class);
+    private static final EventDescriptor<Integer> EVENT_1 = EventDescriptor.of("EVENT2", Integer.class);
     private static final ConsumerIdentity producerIdentity = groupGroup("EVENTP");
 
     private static final Pagination THOUSAND = Pagination.fromOffsetAndLimit(0, 1000);
 
-    @Before
-    public void cleanup() {
-        try (Jedis jedis = redis.getJedisPool().getResource()) {
-            jedis.flushDB();
-        }
-    }
-
     @Test
-    public void testQueryUnprocessed() throws SerializationException, InterruptedException {
+    public void testQueryUnprocessed() throws SerializationException {
 
         final ExecutorService executor = Executors.newFixedThreadPool(4);
         //TODO: ezt a DefaultKeyNaming.ofPrefix-et nem itt kellene hívni, hanem legalábbis a CommunicationEndpoint-tól lekérni
@@ -50,7 +39,7 @@ public class QueryEventsTest extends AbstractRedisTest {
         producer.start();
 
         for (int i = 0; i < 10; i++) {
-            producer.asyncSendEvent(EVENT_1, singletonMap("index", i));
+            producer.asyncSendEvent(EVENT_1, i);
         }
 
         final ListResult<UUID> uuids = reporting.queryEventUuids("EVENT2", EventFilters.forStatus(DataHandling.Statuses.CREATED), THOUSAND);

--- a/test/hu/dbx/kompot/ng/reports/QuerySingleEventTest.java
+++ b/test/hu/dbx/kompot/ng/reports/QuerySingleEventTest.java
@@ -15,11 +15,8 @@ import hu.dbx.kompot.report.EventData;
 import hu.dbx.kompot.report.EventGroupData;
 import hu.dbx.kompot.report.Reporting;
 import org.hamcrest.Matchers;
-import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -28,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
-import static java.util.Collections.singletonMap;
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.*;
 
@@ -36,16 +32,9 @@ public class QuerySingleEventTest extends AbstractRedisTest {
 
     private static final String EVENT_NAME = "TEST_EVENT_" + QuerySingleEventTest.class.getName();
 
-    private static final EventDescriptor<Map> EVENT_1 = EventDescriptor.of(EVENT_NAME, Map.class);
+    private static final EventDescriptor<String> EVENT_1 = EventDescriptor.of(EVENT_NAME, String.class);
     private static final ConsumerIdentity consumerIdentity = groupGroup(EVENT_NAME);
     private static final ConsumerIdentity producerIdentity = groupGroup("EVENTP");
-
-    @Before
-    public void before() {
-        try (Jedis jedis = redis.getJedisPool().getResource()) {
-            jedis.flushDB();
-        }
-    }
 
     /**
      * Egy konkrét esemény adatainak lekérdezése. Az esemény UUID-ját az eseményküldés callbackből szedjük ki
@@ -70,7 +59,7 @@ public class QuerySingleEventTest extends AbstractRedisTest {
             }
         });
         producer.start();
-        producer.asyncSendEvent(EVENT_1, singletonMap("aa", 0));
+        producer.asyncSendEvent(EVENT_1, "aa");
         producer.stop();
 
         assertNotNull(sentEventUuid[0]);
@@ -96,7 +85,7 @@ public class QuerySingleEventTest extends AbstractRedisTest {
      * Egy konkrét esemény életciklusának végigjátszása
      */
     @Test
-    public void querySingleEventLifecycle() throws SerializationException, InterruptedException {
+    public void querySingleEventLifecycle() throws SerializationException {
         final ExecutorService executor = Executors.newFixedThreadPool(4);
         final AtomicReference<UUID> sentEventUuid = new AtomicReference<>();
 
@@ -116,7 +105,7 @@ public class QuerySingleEventTest extends AbstractRedisTest {
             }
         });
         producer.start();
-        producer.asyncSendEvent(EVENT_1, singletonMap("aa", 0));
+        producer.asyncSendEvent(EVENT_1, "aa");
         producer.stop();
 
         final UUID sentUUID = await("Sent event uuid should be set").atMost(1, TimeUnit.SECONDS).untilAtomic(sentEventUuid, Matchers.notNullValue());

--- a/test/hu/dbx/kompot/ng/reports/QuerySingleEventTest.java
+++ b/test/hu/dbx/kompot/ng/reports/QuerySingleEventTest.java
@@ -1,7 +1,6 @@
 package hu.dbx.kompot.ng.reports;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.consumer.async.EventFrame;
@@ -10,12 +9,13 @@ import hu.dbx.kompot.consumer.async.handler.SelfDescribingEventProcessor;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.DataHandling;
 import hu.dbx.kompot.impl.DefaultKeyNaming;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.report.EventData;
 import hu.dbx.kompot.report.EventGroupData;
 import hu.dbx.kompot.report.Reporting;
+import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
@@ -24,22 +24,21 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.Collections.singletonMap;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.*;
 
-public class QuerySingleEventTest {
+public class QuerySingleEventTest extends AbstractRedisTest {
 
     private static final String EVENT_NAME = "TEST_EVENT_" + QuerySingleEventTest.class.getName();
 
     private static final EventDescriptor<Map> EVENT_1 = EventDescriptor.of(EVENT_NAME, Map.class);
     private static final ConsumerIdentity consumerIdentity = groupGroup(EVENT_NAME);
     private static final ConsumerIdentity producerIdentity = groupGroup("EVENTP");
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Before
     public void before() {
@@ -120,12 +119,11 @@ public class QuerySingleEventTest {
         producer.asyncSendEvent(EVENT_1, singletonMap("aa", 0));
         producer.stop();
 
-        Thread.sleep(100);
-        assertNotNull(sentEventUuid.get());
+        final UUID sentUUID = await("Sent event uuid should be set").atMost(1, TimeUnit.SECONDS).untilAtomic(sentEventUuid, Matchers.notNullValue());
 
         {
             //az esemény feldolgozás előtt van
-            final Optional<EventGroupData> eventGroupDataOpt = reporting.querySingleEvent(EVENT_1.getEventName(), sentEventUuid.get());
+            final Optional<EventGroupData> eventGroupDataOpt = reporting.querySingleEvent(EVENT_1.getEventName(), sentUUID);
             assertTrue(eventGroupDataOpt.isPresent());
             assertEquals(DataHandling.Statuses.CREATED, eventGroupDataOpt.get().getStatus());
         }
@@ -142,7 +140,14 @@ public class QuerySingleEventTest {
         }));
         consumer.start();
 
-        Thread.sleep(500);
+        await("Consumer should run for at least half a second").during(500, TimeUnit.MILLISECONDS).until(consumer::isRunning);
+
+        {
+            //az esemény feldolgozás után van
+            final Optional<EventGroupData> eventGroupDataOpt = reporting.querySingleEvent(EVENT_1.getEventName(), sentEventUuid.get());
+            assertTrue(eventGroupDataOpt.isPresent());
+            assertEquals(DataHandling.Statuses.PROCESSED, eventGroupDataOpt.get().getStatus());
+        }
 
         {
             //az esemény feldolgozás után van
@@ -151,5 +156,7 @@ public class QuerySingleEventTest {
             assertEquals(DataHandling.Statuses.PROCESSED, eventGroupDataOpt.get().getStatus());
         }
         consumer.stop();
+        executor.shutdown();
+        await("Executor should terminate").atMost(1, TimeUnit.SECONDS).until(executor::isTerminated);
     }
 }

--- a/test/hu/dbx/kompot/ng/reports/RemoveEventTest.java
+++ b/test/hu/dbx/kompot/ng/reports/RemoveEventTest.java
@@ -1,7 +1,6 @@
 package hu.dbx.kompot.ng.reports;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
 import hu.dbx.kompot.consumer.async.EventDescriptor;
 import hu.dbx.kompot.consumer.async.EventFrame;
@@ -9,11 +8,11 @@ import hu.dbx.kompot.consumer.async.EventSendingCallback;
 import hu.dbx.kompot.exceptions.SerializationException;
 import hu.dbx.kompot.impl.DataHandling;
 import hu.dbx.kompot.impl.DefaultKeyNaming;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.report.Reporting;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
@@ -26,13 +25,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
 import static java.util.Collections.singletonMap;
 
-public class RemoveEventTest {
+public class RemoveEventTest extends AbstractRedisTest {
 
     private static final EventDescriptor<Map> EVENT_1 = EventDescriptor.of("EVENT3", Map.class);
     private static final ConsumerIdentity producerIdentity = groupGroup("EVENTP");
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Before
     public void before() {

--- a/test/hu/dbx/kompot/ng/reports/RemoveEventTest.java
+++ b/test/hu/dbx/kompot/ng/reports/RemoveEventTest.java
@@ -12,30 +12,19 @@ import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.report.Reporting;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.groupGroup;
-import static java.util.Collections.singletonMap;
 
 public class RemoveEventTest extends AbstractRedisTest {
 
-    private static final EventDescriptor<Map> EVENT_1 = EventDescriptor.of("EVENT3", Map.class);
+    private static final EventDescriptor<String> EVENT_1 = EventDescriptor.of("EVENT3", String.class);
     private static final ConsumerIdentity producerIdentity = groupGroup("EVENTP");
-
-    @Before
-    public void before() {
-        try (Jedis jedis = redis.getJedisPool().getResource()) {
-            jedis.flushDB();
-        }
-    }
 
     @Test
     public void removeEvent() throws SerializationException {
@@ -58,7 +47,7 @@ public class RemoveEventTest extends AbstractRedisTest {
             }
         });
         producer.start();
-        producer.asyncSendEvent(EVENT_1, singletonMap("aa", 0));
+        producer.asyncSendEvent(EVENT_1, "aa");
         producer.stop();
 
         Assert.assertEquals(DataHandling.Statuses.CREATED, reporting.querySingleEvent("EVENT3", sentEventUuid.get()).get().getStatus());

--- a/test/hu/dbx/kompot/ng/status/StatusReportTest.java
+++ b/test/hu/dbx/kompot/ng/status/StatusReportTest.java
@@ -1,35 +1,33 @@
 package hu.dbx.kompot.ng.status;
 
 import hu.dbx.kompot.CommunicationEndpoint;
-import hu.dbx.kompot.TestRedis;
 import hu.dbx.kompot.consumer.ConsumerIdentity;
+import hu.dbx.kompot.ng.AbstractRedisTest;
 import hu.dbx.kompot.producer.EventGroupProvider;
 import hu.dbx.kompot.status.StatusReport;
 import hu.dbx.kompot.status.StatusReporter;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static hu.dbx.kompot.impl.DefaultConsumerIdentity.fromGroups;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.*;
+import static org.awaitility.Awaitility.await;
 
 /**
  * A tuloldalon kivetel kepzodott.
  */
 @SuppressWarnings("unchecked")
-public class StatusReportTest {
+public class StatusReportTest extends AbstractRedisTest {
 
     private static final ConsumerIdentity consumerIdentity = fromGroups("EGROUP", "MGROUP");
 
-
-    @Rule
-    public TestRedis redis = TestRedis.build();
 
     @Test
     public void testFindsOwnStatusReporter() throws InterruptedException {
@@ -40,10 +38,12 @@ public class StatusReportTest {
 
         consumer.start();
 
-        // TODO: what if i remove the sleep here: why does it fail?
-        Thread.sleep(2000L);
-        final List<StatusReport> statuses = consumer.findGlobalStatuses();
+        await().during(1, TimeUnit.SECONDS).atMost(2, TimeUnit.SECONDS).until(() -> {
+            final List<StatusReport> statuses = consumer.findGlobalStatuses();
+            return statuses.size() == 1;
+        });
 
+        final List<StatusReport> statuses = consumer.findGlobalStatuses();
         assertEquals(1, statuses.size());
 
 
@@ -82,8 +82,10 @@ public class StatusReportTest {
 
         consumer.start();
 
-        // TODO: what if i remove the sleep here: why does it fail?
-        Thread.sleep(2000L);
+        await().during(1, TimeUnit.SECONDS).atMost(2, TimeUnit.SECONDS).until(() -> {
+            final List<StatusReport> statuses = consumer.findGlobalStatuses();
+            return statuses.size() == 1;
+        });
         final List<StatusReport> statuses = consumer.findGlobalStatuses();
 
         assertEquals(1, statuses.size());


### PR DESCRIPTION
The original EVENT ordering caused the events to be processed in a LIFO manner